### PR TITLE
libc6-dev-i386 installation command for facilitating make iss

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Get the latest perl module:
 sudo apt-get install perl
 ```
 
+```sh
+sudo apt-get install libc6-dev-i386
+```
+
 The SimpleCPU project has been tested on Linux (Ubuntu 14.04) only. Though it shouldn't be hard to port the scripts for windows as well. We are working towards testing the project on windows environment as well. 
 
 <a id="Documentation"></a>


### PR DESCRIPTION
To facilitate make of iss we need the ubuntu user to install the libc6-dev-i386 library